### PR TITLE
fix the classpath.

### DIFF
--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -266,7 +266,7 @@ def ensure_topic(config, file, timeout, create_if_not_exists):
     cmd_template = """
              java {jvm_opts} \
                  -cp {classpath} \
-                 io.confluent.admin.utils.cli.TopicEnsureCommand \
+                 io.confluent.kafkaensure.cli.TopicEnsureCommand \
                  --config {config} \
                  --file {file} \
                  --create-if-not-exists {create_if_not_exists} \


### PR DESCRIPTION
@confluentinc/caas 

This class path is not correct. Found this issue in healthcheck testing.
#jar -tf /usr/share/java/cc-base/utility-belt-4.0.0-20171127.075423-84.jar
.....
io/confluent/kafkaensure/cli/TopicEnsureCommand.class
.....