### PR TITLE
Add cp-base-new to the classpath

### DIFF
--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -40,7 +40,7 @@ import re
 import requests
 import subprocess
 
-CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*"')
+CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*"')
 
 
 def wait_for_service(host, port, timeout):


### PR DESCRIPTION
It has been renamed to cp-base-new in common-docker, and so we need to
support both old and new paths.