### PR TITLE
Add paramiko 2.4.2 to the list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.9.128
-paramiko=2.4.2
+paramiko==2.4.2
 docker==3.7.2
 docker-compose==1.24.0
 Jinja2==2.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.9.128
+paramiko=2.4.2
 docker==3.7.2
 docker-compose==1.24.0
 Jinja2==2.9.6


### PR DESCRIPTION
https://jenkins.confluent.io/job/confluentinc/job/ksql-images/job/master/894/consoleFull reports that [INFO] _=/usr/bin/env
[INFO] ===> User
[INFO] uid=0(root) gid=0(root) groups=0(root)
[INFO] ===> Configuring ...
[INFO] Traceback (most recent call last):
[INFO]   File "/usr/local/bin/dub", line 6, in <module>
[INFO]     from pkg_resources import load_entry_point
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3019, in <module>
[INFO] 
[INFO]     @_call_aside
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3003, in _call_aside
[INFO] 
[INFO]     f(*args, **kwargs)
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3032, in _initialize_master_working_set
[INFO] 
[INFO]     working_set = WorkingSet._build_master()
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 655, in _build_master
[INFO] 
[INFO]     ws.require(__requires__)
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 963, in require
[INFO] 
[INFO]     needed = self.resolve(parse_requirements(requirements))
[INFO]   File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 849, in resolve
[INFO] 
[INFO]     raise DistributionNotFound(req, requirers)
[INFO] pkg_resources.DistributionNotFound
[INFO] : The 'paramiko>=2.4.2' distribution was not found and is required by docker

Maybe we should add paramiko to the requirement list.