### PR TITLE
SEC-645: Upgrading version of docker-compose to use latest version of PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.9.128
 paramiko==2.4.2
 docker==3.7.2
-docker-compose==1.24.0
+docker-compose==1.25.2
 Jinja2==2.9.6
 mock==2.0.0
 requests==2.20.0


### PR DESCRIPTION
The version of PyYAML used by the older version of docker-compose has a security vulnerability. This new version of docker compose uses the latest version of PyYAML.