### PR TITLE
Update module six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Jinja2==2.9.6
 mock==2.0.0
 requests==2.20.0
 cryptography==2.7
+six==1.14.0


### PR DESCRIPTION
# what
ksql images are current failing because 
```
ImportError: No module named six
```
which seems starts from yesterday. I have not yet root cause what cause the issue, but that change can fix the problem.