### PR TITLE
Pin pyrsistent bellow 0.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.9.128
+pyrsistent<0.17.0
 paramiko==2.4.2
 docker==3.7.2
 docker-compose==1.25.2


### PR DESCRIPTION
Confluent Docker Images are failing to build:

```
17:01:52  ==================================== ERRORS ====================================
17:01:52  ___________________ ERROR collecting test/test_base_image.py ___________________
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/_pytest/python.py:507: in _importtestmodule
17:01:52      mod = self.fspath.pyimport(ensuresyspath=importmode)
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/py/_path/local.py:704: in pyimport
17:01:52      __import__(modname)
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/_pytest/assertion/rewrite.py:304: in load_module
17:01:52      exec(co, mod.__dict__)
17:01:52  test/test_base_image.py:4: in <module>
17:01:52      import confluent.docker_utils as utils
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/confluent/docker_utils/__init__.py:7: in <module>
17:01:52      from compose.config.config import ConfigDetails, ConfigFile, load
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/compose/config/__init__.py:6: in <module>
17:01:52      from .config import ConfigurationError
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/compose/config/config.py:51: in <module>
17:01:52      from .validation import match_named_volumes
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/compose/config/validation.py:12: in <module>
17:01:52      from jsonschema import Draft4Validator
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/jsonschema/__init__.py:21: in <module>
17:01:52      from jsonschema._types import TypeChecker
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/jsonschema/_types.py:3: in <module>
17:01:52      from pyrsistent import pmap
17:01:52  /var/tmp/confluent/lib/python2.7/site-packages/pyrsistent/__init__.py:3: in <module>
17:01:52      from pyrsistent._pmap import pmap, m, PMap
17:01:52  E     File "/var/tmp/confluent/lib/python2.7/site-packages/pyrsistent/_pmap.py", line 98
17:01:52  E       ) from e
17:01:52  E            ^
17:01:52  E   SyntaxError: invalid syntax
```

Due to https://github.com/tobgu/pyrsistent/pull/206 - If the maintainers yank the 0.17.0 release & add a `python_requires` & re-publish, then we won't have to take an action, otherwise this will be required.