### PR TITLE
Bump requests version to pull in newer versions of python packages that address some CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 boto3==1.9.128
-pyrsistent<0.17.0
 paramiko==2.4.2
 docker==3.7.2
 docker-compose==1.25.2
 Jinja2==2.11.2
 mock==2.0.0
-requests==2.20.0
+requests<=2.25.0
 cryptography>=2.6.1
 six==1.14.0


### PR DESCRIPTION
* Specifically urllib3 & CVE-2020-26137

Removed the pyresilient pin, as that was done for python27 compatible packages (The Debian Docker Images), going forward, `master` will be for python3-compatible packages (CP 6.0 +). For CP < 5.5, I've made a branch from `v0.40.0` called `python27-compat` which is where we can maintain python27 dependencies.

Testing the change here: https://github.com/confluentinc/common-docker/pull/116 in 6.0.x, builds and it installs a newer version of urllib3:

```
15:43:25  [INFO] Successfully installed Jinja2-2.11.2 MarkupSafe-1.1.1 PyYAML-5.3.1 attrs-20.3.0 bcrypt-3.2.0 boto3-1.9.128 botocore-1.12.253 cached-property-1.5.2 certifi-2020.12.5 cffi-1.14.4 chardet-3.0.4 confluent-docker-utils-0.0.41 cryptography-3.2.1 docker-3.7.2 docker-compose-1.25.2 docker-pycreds-0.4.0 dockerpty-0.4.1 docopt-0.6.2 docutils-0.15.2 idna-2.10 importlib-metadata-3.1.1 jmespath-0.10.0 jsonschema-3.2.0 mock-2.0.0 paramiko-2.4.2 pbr-5.5.1 pyasn1-0.4.8 pycparser-2.20 pynacl-1.4.0 pyrsistent-0.17.3 python-dateutil-2.8.1 requests-2.25.0 s3transfer-0.2.1 setuptools-51.0.0 six-1.14.0 texttable-1.6.3 urllib3-1.26.2 websocket-client-0.57.0 zipp-3.4.0
```

The PR job runs these tests against the built docker images: https://github.com/confluentinc/common-docker/blob/ST-4684/base/test/test_base_image.py#L19-L23

Which test running the `cub` and `dub` scripts - They still function.