### PR TITLE
UPDATE: Loosen dependency requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-boto3==1.9.128
-paramiko==2.4.2
-docker==3.7.2
-docker-compose==1.25.2
-Jinja2==2.11.2
-mock==2.0.0
-requests<=2.25.0
-cryptography>=2.6.1
-six==1.14.0
+boto3~=1.17
+paramiko~=2.7
+docker~=4.4
+docker-compose~=1.28
+Jinja2~=2.11
+mock~=4.0
+requests~=2.25
+cryptography~=3.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 
     include_package_data=True,
 
-    python_requires='>=2.7',
+    python_requires='>=3.6',
     setup_requires=['setuptools-git'],
 
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
-envlist = py27,py3
+envlist = py3
 toxworkdir = {homedir}/.virtualenvs/docker_utils
-
-[testenv:py27]
-basepython = python2.7
 
 [testenv:py3]
 basepython = python3


### PR DESCRIPTION
- Loosening dependency requirements to stay on Major version to get
automatic patch updates (Looking for a Jinja-2.11.3 update)
- Also officially dropping py27 support with this update - enforced in setup.py, and removed in tox.ini.

Helper PR in docker-common shows the UBI image was installed with:

```
[2021-02-10T00:38:51.911Z] [INFO] Successfully installed Jinja2-2.11.3 MarkupSafe-1.1.1 PyYAML-5.4.1 attrs-20.3.0 bcrypt-3.2.0 boto3-1.17.4 botocore-1.20.5 cached-property-1.5.2 certifi-2020.12.5 cffi-1.14.4 chardet-4.0.0 confluent-docker-utils-0.0.42 cryptography-3.4.4 distro-1.5.0 docker-4.4.1 docker-compose-1.28.2 dockerpty-0.4.1 docopt-0.6.2 idna-2.10 importlib-metadata-3.4.0 jmespath-0.10.0 jsonschema-3.2.0 mock-4.0.3 paramiko-2.7.2 pycparser-2.20 pynacl-1.4.0 pyrsistent-0.17.3 python-dateutil-2.8.1 python-dotenv-0.15.0 requests-2.25.1 s3transfer-0.3.4 six-1.15.0 texttable-1.6.3 typing-extensions-3.7.4.3 urllib3-1.26.3 websocket-client-0.57.0 zipp-3.4.0
```