### PR TITLE
env_to_props: Fix example in docstring

### DIFF
--- a/confluent/docker_utils/dub.py
+++ b/confluent/docker_utils/dub.py
@@ -67,7 +67,7 @@ def env_to_props(env_prefix, prop_prefix, exclude=[]):
             {
                 'confluent.controlcenter.streams.security.protocol': 'SASL_SSL',
                 'confluent.controlcenter.streams.with_underscore': 'foo',
-                'confluent.controlcenter.streams.with_dash': 'bar',
+                'confluent.controlcenter.streams.with-dash': 'bar',
                 'confluent.controlcenter.streams.sasl.kerberos.service.name': 'kafka'
             }
 


### PR DESCRIPTION
If I understand this correctly, `CONTROL_CENTER_STREAMS_WITH___DASH` should result in `controlcenter.streams.with-dash`, not `controlcenter.streams.with_dash`.