### PR TITLE
Require python >=3.6.15 and fix failing master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ python {
   owner = 'tools'
   slackChannel = 'devprod-notifications'
   // uses docker for testing, but nor for publishing.
-  nodeLabel = 'docker-ubuntu-20-python'
+  nodeLabel = 'docker-debian-jdk8'
   usesDockerForTesting = true
   dockerPush = false
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ paramiko~=2.7
 docker~=5.0
 docker-compose~=1.29
 Jinja2~=2.11
+markupsafe==2.0.1
 mock~=4.0
 requests~=2.25
 cryptography~=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ paramiko~=2.7
 docker~=5.0
 docker-compose~=1.29
 Jinja2~=2.11
-markupsafe==2.0.1
+markupsafe~=2.0.1
 mock~=4.0
 requests~=2.25
 cryptography~=3.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 
     include_package_data=True,
 
-    python_requires='>=3.6',
+    python_requires='>=3.6.15',
     setup_requires=['setuptools-git'],
 
     entry_points={


### PR DESCRIPTION
### Changes
Upgrade Python to 3.6.15 as requested in https://confluentinc.atlassian.net/browse/DP-7604 . Python 3.6.15 is [the latest for 3.6](https://www.python.org/downloads/release/python-3615/ ), addressing CVE https://nvd.nist.gov/vuln/detail/CVE-2021-3737. _This is a blocker for CFK patch releases tomorrow._

Fix the master branch which has been failing for a few months now. These changes include:
- Use `docker-debian-jdk8` nodelabel instead
- Pin markupsafe to 2.0.1 (as 2.1.0 [no longer includes soft_unicode](https://github.com/aws/aws-sam-cli/issues/3661))

**Follow-Up**
Once confluent-docker-utils has a new tag published, we will need to update common-docker in https://github.com/confluentinc/common-docker/commits/master/base/requirements.txt to have it used for our CFK and CP images