### PR TITLE
[minor] Relax Python requirement back to >=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
 
     include_package_data=True,
 
-    python_requires='>=3.6.15',
+    python_requires='>=3.6',
     setup_requires=['setuptools-git'],
 
     entry_points={


### PR DESCRIPTION
Following exception request granted [here](https://confluentinc.atlassian.net/browse/DP-7604) , we do not need to upgrade Python to 3.6.15 at this time and will look into upgrading to 3.9 next quarter