### PR TITLE
Fix typo and check file existence

### DIFF
--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -94,10 +94,13 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
     return requests.get(url, verify = not ignore_cert, auth = auth)
 
 def log4j_config_file():
+    def default_config = "/etc/cp-base-new/log4j.properties"
     if (os.environ.get("COMPONENT")):
-        return "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
-    else:
-        return "/etc/cp-base-new/log4j.properties"
+        def component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
+        # check component_config exists, else default to cp-base-new
+        if os.path.exists(component_config):
+            return component_config
+    return default_config
 
 def check_zookeeper_ready(connect_string, timeout):
     """Waits for a Zookeeper ensemble be ready. This commands uses the Java
@@ -404,7 +407,7 @@ def ensure_topic(config, file, timeout, create_if_not_exists):
     """
     cmd_template = """
              java {jvm_opts} \
-                 -Dlog4j.configuration=file:/{log4j_config} \
+                 -Dlog4j.configuration=file:{log4j_config} \
                  -cp {classpath} \
                  io.confluent.kafkaensure.cli.TopicEnsureCommand \
                  --config {config} \

--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -45,6 +45,7 @@ from requests.auth import HTTPBasicAuth
 import subprocess
 
 CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*"')
+DEFAULT_LOG4J_FILE = "/etc/cp-base-new/log4j.properties"
 
 
 def wait_for_service(host, port, timeout):
@@ -94,13 +95,13 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
     return requests.get(url, verify = not ignore_cert, auth = auth)
 
 def log4j_config_file():
-    def default_config = "/etc/cp-base-new/log4j.properties"
-    if (os.environ.get("COMPONENT")):
-        def component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
-        # check component_config exists, else default to cp-base-new
-        if os.path.exists(component_config):
-            return component_config
-    return default_config
+    def config_file = DEFAULT_LOG4J_FILE
+    def component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
+    # check component_config exists, else default to cp-base-new
+    if os.environ.get("COMPONENT") and os.path.exists(component_config):
+        config_file = component_config
+    print("Using log4j config %s", config_file)
+    return config_file
 
 def check_zookeeper_ready(connect_string, timeout):
     """Waits for a Zookeeper ensemble be ready. This commands uses the Java

--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -95,8 +95,8 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
     return requests.get(url, verify = not ignore_cert, auth = auth)
 
 def log4j_config_file():
-    def config_file = DEFAULT_LOG4J_FILE
-    def component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
+    config_file = DEFAULT_LOG4J_FILE
+    component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
     # check component_config exists, else default to cp-base-new
     if os.environ.get("COMPONENT") and os.path.exists(component_config):
         config_file = component_config


### PR DESCRIPTION
Address PR comments from #48 
- Fix typo in `ensure_topic()`
- Check for file existence for component-specific config, else default to cp-base-new's log4j.properties

After this is merged to master, I'll bump common-docker to point to the newly published version of `confluent-docker-utils` (similar to this [previous version bump](https://github.com/confluentinc/common-docker/pull/241)), including common-docker 5.4.x and 5.5.x which are currently pinned to older version for compatibility issues. Then will kick off some updated `cp-docker-images-overlay` builds.