### PR TITLE
Add missing TelemetryReporter class to CUB_CLASSPATH

### DIFF
--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -44,7 +44,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import subprocess
 
-CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*"')
+CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*:/usr/share/java/confluent-telemetry/*"')
 DEFAULT_LOG4J_FILE = "/etc/cp-base-new/log4j.properties"
 
 


### PR DESCRIPTION
Kafka Connect fails to start up when Confluent Telemetry is enabled.

container logs:
```sh
kubectl logs kafka-connect -f
===> Configuring ...
===> Running preflight checks ... 
===> Check if Kafka is healthy ...
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-simple-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
Error while running kafka-ready.
org.apache.kafka.common.KafkaException: Failed to create new KafkaAdminClient
	at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:538)
	at org.apache.kafka.clients.admin.Admin.create(Admin.java:143)
	at org.apache.kafka.clients.admin.AdminClient.create(AdminClient.java:49)
	at io.confluent.admin.utils.ClusterStatus.isKafkaReady(ClusterStatus.java:136)
	at io.confluent.admin.utils.cli.KafkaReadyCommand.main(KafkaReadyCommand.java:149)
Caused by: org.apache.kafka.common.KafkaException: Class io.confluent.telemetry.reporter.TelemetryReporter cannot be found
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:396)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstances(AbstractConfig.java:478)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstances(AbstractConfig.java:459)
	at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:494)
	... 4 more
Caused by: java.lang.ClassNotFoundException: io.confluent.telemetry.reporter.TelemetryReporter
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at org.apache.kafka.common.utils.Utils.loadClass(Utils.java:419)
	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:408)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:394)
... 7 more
```

Workaround via env (k8s):
```yaml
  env:
    - name: CUB_CLASSPATH
      value: "/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*:/usr/share/java/confluent-telemetry/*"
```