### PR TITLE
fix tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
     PIP_DEFAULT_TIMEOUT=60
     ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
 # docker-py / boto3
-passenv = DOCKER_* AWS_*
+passenv = DOCKER_*,AWS_*
 commands =
      # https://github.com/tox-dev/tox/issues/149
      pip install -q -r {toxinidir}/requirements.txt


### PR DESCRIPTION
whitespace is not used in the new version of tox. This is causing the master build failure.
