### PR TITLE
replace homedir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py3
-toxworkdir = {homedir}/.virtualenvs/docker_utils
+toxworkdir = {env:HOME:.}/.virtualenvs/docker_utils
 
 [testenv:py3]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py3
-toxworkdir = {env:HOME:.}/.virtualenvs/docker_utils
+toxworkdir = {package_root}/.virtualenvs/docker_utils
 
 [testenv:py3]
 basepython = python3


### PR DESCRIPTION
`homedir` substitution is no longer supported for tox new version as well. refer to: https://tox.wiki/en/latest/config.html#environment-variable-substitutions

It's weird that the last PR build is successful despite it is still using `homedir`

update:  loos like the PR build didn't run the test.