### PR TITLE
DP-13727 Add CodeArtifact package paths to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,6 +3,10 @@ lang: unknown
 lang_version: unknown
 git:
   enable: true
-semaphore: 
+semaphore:
   enable: true
   pipeline_enable: false
+code_artifact:
+  enable: true
+  package_paths:
+    - pypi-internal/pypi//confluent-docker-utils


### PR DESCRIPTION
One of the Capsaicin requirements requires that all artifacts uploaded to CodeArtifacts come from specific Semaphore jobs.
This PR adds package_paths to service.yml so that each GitHub repo can declare the path of the CodeArtifact packages that it writes to.
For newer GitHub repos, the package_paths needs to be added to the service.yml file manually before it can write to CodeArtifact in the Semaphore pipeline.
For more information about this, see https://confluent.slack.com/archives/C038ZJ00P/p1708464192287999
