### PR TITLE
fix: add `MANIFEST.in` file for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include confluent *
+include requirements.txt


### PR DESCRIPTION
This should allow sdists to install correctly.

Fixes: Issue #84
