### PR TITLE
fix: add `MANIFEST.in` file for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include confluent *
+include requirements.txt


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
Copy of https://github.com/confluentinc/confluent-docker-utils/pull/85

> This should allow sdists to install correctly.
>
> Fixes: Issue https://github.com/confluentinc/confluent-docker-utils/issues/84

### Testing
<!-- a description of how you tested the change -->
PR checks