### PR TITLE
push branch before tag during release

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,6 +48,6 @@ blocks:
             - git tag -f $LATEST_TAG
             - rm -rf dist/*
             - python setup.py sdist bdist_wheel
-            - twine upload --repository codeartifact dist/*
             - git push origin $SEMAPHORE_GIT_BRANCH
             - git push origin $LATEST_TAG
+            - twine upload --repository codeartifact dist/*

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,4 +49,5 @@ blocks:
             - rm -rf dist/*
             - python setup.py sdist bdist_wheel
             - twine upload --repository codeartifact dist/*
-            - git push origin $SEMAPHORE_GIT_BRANCH $LATEST_TAG
+            - git push origin $SEMAPHORE_GIT_BRANCH
+            - git push origin $LATEST_TAG


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This changes the release process so the branch with the incremented version is pushed before the git tag and CodeArtifact push. When the git tag and branch are pushed in the same command, one can succeed and one can fail. This typically happens when multiple PRs are merged at the same time. This causes a breakage because the branch is the source of truth for the version. If the git tag or the latest CodeArtifact version is ahead of the branch version, then the release process will attempt to overwrite a pre-existing tag or CodeArtifact version and it will fail. This gets it into a state where all subsequent releases fail.

### Testing
<!-- a description of how you tested the change -->
N/A - can only be tested on master