### PR TITLE
Revert "manually increment version (#119)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='confluent-docker-utils',
-    version='0.0.87',
+    version='0.0.86',
 
     author="Confluent, Inc.",
     author_email="partner-support@confluent.io",


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This reverts commit 9ecfcf0681cd6e4c7520859ac474aad0851297be. https://github.com/confluentinc/confluent-docker-utils/pull/119.

This caused the CI pipeline to fail in a new way, https://semaphore.ci.confluent.io/jobs/5dfadf4d-5952-4095-811f-10bbeb814b94#L311.

### Testing
<!-- a description of how you tested the change -->
