### PR TITLE
determine the current version using setuptools

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,14 +34,9 @@ blocks:
             - pip install -r test-requirements.txt
             - git checkout $SEMAPHORE_GIT_BRANCH
             - git reset --hard
-            - VERSION_STRING=$(grep 'version\s*=\s*' setup.py || true)
-            - >-
-              if [ -z "$VERSION_STRING" ]; then
-                  SETUP_FILE="setup.cfg"
-              else
-                  SETUP_FILE="setup.py"
-              fi
-            - bumpversion patch $SETUP_FILE --tag --verbose --commit --message "$COMMIT_MESSAGE_PREFIX {new_version}"
+            - setup_file="setup.py"
+            - current_version=$(python $setup_file --version)
+            - bumpversion patch $setup_file --tag --verbose --commit --message "$COMMIT_MESSAGE_PREFIX {new_version}" --current-version $current_version
             - LATEST_TAG=$(git describe --tags --abbrev=0)
             - echo "LATEST_TAG - $LATEST_TAG"
             - git commit --amend -C HEAD

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,6 @@ pytest-cov==5.0.0
 Mako==1.3.5
 MarkupSafe==2.1.5
 mock==5.1.0
+setuptools==75.1.0
 twine==5.1.1
 wheel==0.44.0
-


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
In https://github.com/confluentinc/confluent-docker-utils/pull/119, the version in `setup.py` was manually incremented to match CodeArtifact and the git tag. However, the master branch is now failing like https://semaphore.ci.confluent.io/jobs/5dfadf4d-5952-4095-811f-10bbeb814b94#L311. This is because `bumpversion` still sees the current version as n-1.  It's not clear to me why. This changes the logic to explicitly pass in the current version to `bumpversion`. The current version will come from `setup.py` as the definitive source of truth.

### Testing
<!-- a description of how you tested the change -->
