### PR TITLE
remove mako and markupsafe dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,8 +3,6 @@ flake8==7.1.1
 pytest==8.3.3
 pytest-xdist==3.6.1
 pytest-cov==5.0.0
-Mako==1.3.5
-MarkupSafe==2.1.5
 mock==5.1.0
 setuptools==75.1.0
 twine==5.1.1


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This removes the `Mako` and `MarkupSafe` test dependencies. These dependencies are unused.

### Testing
<!-- a description of how you tested the change -->
PR checks