### PR TITLE
Change pip installs to not use -q

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ setenv =
 passenv = DOCKER_*,AWS_*
 commands =
      # https://github.com/tox-dev/tox/issues/149
-     pip install -q -r {toxinidir}/requirements.txt
-     pip install -q -r {toxinidir}/test-requirements.txt
+     pip install -r {toxinidir}/requirements.txt
+     pip install -r {toxinidir}/test-requirements.txt
      py.test {env:PYTESTARGS:} test
 
 [testenv:style]


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This changes the pip installs to not run in quiet mode. There is currently a failure in the installs in the https://github.com/confluentinc/confluent-docker-utils/pull/140 CI job, but there isn't enough debugging information to determine why.

### Testing
<!-- a description of how you tested the change -->
PR checks