### PR TITLE
upgrade to python 3.9

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,7 +9,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version python 3.8
+      - sem-version python 3.9
       - pip install tox
       - COMMIT_MESSAGE_PREFIX="[ci skip] Publish version"
 blocks:


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
This changes the Semaphore job to use Python 3.9. Python 3.8 is now EOL. Not bumping major version because there isn't a hard requirement on Python > 3.8 by any runtime dependency.

### Testing
<!-- a description of how you tested the change -->
PR checks