### PR TITLE
CPBR-2474: add support for using log4j2 

### DIFF
--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -35,16 +35,20 @@ These commands log any output to stderr and returns with exitcode 0 if successfu
 
 """
 from __future__ import print_function
+
 import os
-import sys
-import socket
-import time
 import re
-import requests
-from requests.auth import HTTPBasicAuth
+import socket
 import subprocess
 
+import requests
+import sys
+import time
+from requests.auth import HTTPBasicAuth
+
 CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*"')
+LOG4J_FILE_NAME = "log4j.properties"
+DEFAULT_LOG4J_FILE = f"/etc/cp-base-new/{LOG4J_FILE_NAME}"
 LOG4J2_FILE_NAME = "log4j2.yaml"
 DEFAULT_LOG4J2_FILE = f"/etc/cp-base-new/{LOG4J2_FILE_NAME}"
 
@@ -96,13 +100,15 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
     return requests.get(url, verify = not ignore_cert, auth = auth)
 
 def log4j2_config_file():
-    config_file = DEFAULT_LOG4J2_FILE
+    use_log4j_2 = os.environ.get("USE_LOG4J_2")
+    config_file = DEFAULT_LOG4J2_FILE if use_log4j_2 else DEFAULT_LOG4J_FILE
     # check component_config exists, else default to cp-base-new
     if os.environ.get("COMPONENT"):
-        component_config = "/etc/" + os.environ.get("COMPONENT") + "/" + LOG4J2_FILE_NAME
+        log_config_file_name = LOG4J2_FILE_NAME if use_log4j_2 else LOG4J_FILE_NAME
+        component_config = "/etc/" + os.environ.get("COMPONENT") + "/" + log_config_file_name
         if os.path.exists(component_config):
             config_file = component_config
-    print(f'Using log4j2 config {config_file}')
+    print(f'Using log4j config {config_file}')
     return config_file
 
 def check_zookeeper_ready(connect_string, timeout):

--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -45,7 +45,8 @@ from requests.auth import HTTPBasicAuth
 import subprocess
 
 CLASSPATH = os.environ.get("CUB_CLASSPATH", '"/usr/share/java/cp-base/*:/usr/share/java/cp-base-new/*"')
-DEFAULT_LOG4J_FILE = "/etc/cp-base-new/log4j.properties"
+LOG4J2_FILE_NAME = "log4j2.yaml"
+DEFAULT_LOG4J2_FILE = f"/etc/cp-base-new/{LOG4J2_FILE_NAME}"
 
 
 def wait_for_service(host, port, timeout):
@@ -94,14 +95,14 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
     auth = HTTPBasicAuth(username, password) if (username or password) else None
     return requests.get(url, verify = not ignore_cert, auth = auth)
 
-def log4j_config_file():
-    config_file = DEFAULT_LOG4J_FILE
+def log4j2_config_file():
+    config_file = DEFAULT_LOG4J2_FILE
     # check component_config exists, else default to cp-base-new
     if os.environ.get("COMPONENT"):
-        component_config = "/etc/" + os.environ.get("COMPONENT") + "/log4j.properties"
+        component_config = "/etc/" + os.environ.get("COMPONENT") + "/" + LOG4J2_FILE_NAME
         if os.path.exists(component_config):
             config_file = component_config
-    print(f'Using log4j config {config_file}')
+    print(f'Using log4j2 config {config_file}')
     return config_file
 
 def check_zookeeper_ready(connect_string, timeout):
@@ -121,7 +122,7 @@ def check_zookeeper_ready(connect_string, timeout):
     cmd_template = """
              java {jvm_opts} \
                  -cp {classpath} \
-                 -Dlog4j.configuration=file:{log4j_config} \
+                 -Dlog4j2.configurationFile={log4j_config} \
                  io.confluent.admin.utils.cli.ZookeeperReadyCommand \
                  {connect_string} \
                  {timeout_in_ms}"""
@@ -139,7 +140,7 @@ def check_zookeeper_ready(connect_string, timeout):
     cmd = cmd_template.format(
         classpath=CLASSPATH,
         jvm_opts=jvm_opts or "",
-        log4j_config=log4j_config_file(),
+        log4j_config=log4j2_config_file(),
         connect_string=connect_string,
         timeout_in_ms=timeout * 1000)
 
@@ -181,7 +182,7 @@ def check_kafka_ready(expected_brokers, timeout, config, bootstrap_broker_list=N
     cmd = cmd_template.format(
         classpath=CLASSPATH,
         jvm_opts=os.environ.get("KAFKA_OPTS") or "",
-        log4j_config=log4j_config_file(),
+        log4j_config=log4j2_config_file(),
         bootstrap_broker_list=bootstrap_broker_list,
         expected_brokers=expected_brokers,
         timeout_in_ms=timeout * 1000)
@@ -420,7 +421,7 @@ def ensure_topic(config, file, timeout, create_if_not_exists):
     cmd = cmd_template.format(
         classpath=CLASSPATH,
         jvm_opts=os.environ.get("KAFKA_OPTS") or "",
-        log4j_config=log4j_config_file(),
+        log4j_config=log4j2_config_file(),
         config=config,
         file=file,
         timeout_in_ms=timeout * 1000,

--- a/confluent/docker_utils/cub.py
+++ b/confluent/docker_utils/cub.py
@@ -101,7 +101,8 @@ def __request(host, port, secure, ignore_cert, username='', password='', path=''
 
 
 def use_log4j2():
-    return os.environ.get("USE_LOG4J_2", None) is not None
+    use_log4j_2 = os.getenv("USE_LOG4J_2", "False")
+    return use_log4j_2.lower() == "true"
 
 
 def log4j_config_arg():

--- a/test/test_docker_utils.py
+++ b/test/test_docker_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 import confluent.docker_utils as utils
 import confluent.docker_utils.dub as dub
-
+from confluent.docker_utils import cub
 
 OFFICIAL_IMAGE = "confluentinc/cp-base:latest"
 
@@ -101,3 +101,21 @@ def test_run_docker_command(official_image):
     expected = b'OpenJDK Runtime Environment (Zulu 8.'
     output = utils.run_docker_command(image=OFFICIAL_IMAGE, command=cmd)
     assert expected in output
+
+
+def test_log4j_config_arg_for_log4j_v1():
+    assert cub.log4j_config_arg() == '-Dlog4j.configuration'
+
+
+def test_log4j_config_arg_for_log4j_v2():
+    with patch('confluent.docker_utils.cub.use_log4j2', return_value=True):
+        assert cub.log4j_config_arg() == '-Dlog4j2.configurationFile'
+
+
+def test_log4j_config_file_for_log4j_v1():
+    assert cub.log4j2_config_file() == "file:/etc/cp-base-new/log4j.properties"
+
+
+def test_log4j_config_file_for_log4j_v2():
+    with patch('confluent.docker_utils.cub.use_log4j2', return_value=True):
+        assert cub.log4j2_config_file() == "/etc/cp-base-new/log4j2.yaml"

--- a/test/test_docker_utils.py
+++ b/test/test_docker_utils.py
@@ -7,7 +7,7 @@ import confluent.docker_utils as utils
 import confluent.docker_utils.dub as dub
 
 
-OFFICIAL_IMAGE = "confluentinc/cp-base:latest"
+OFFICIAL_IMAGE = "confluentinc/cp-base-new:latest"
 
 
 def test_imports():

--- a/test/test_docker_utils.py
+++ b/test/test_docker_utils.py
@@ -7,7 +7,7 @@ import confluent.docker_utils as utils
 import confluent.docker_utils.dub as dub
 
 
-OFFICIAL_IMAGE = "confluentinc/cp-base-new:latest"
+OFFICIAL_IMAGE = "confluentinc/cp-base:latest"
 
 
 def test_imports():


### PR DESCRIPTION
### Change Description
This PR adds support to use log4j2 configuration file when running cub commands. It will work along with log4j and log4j2 both to allow CP 7.x and CP 8.x compatibility. 
log4j2 configuration will be used if `USE_LOG4J_2` env variable is set else it will default to continue using log4j configuration.

### Testing
Added basic unit tests for this change.
