### PR TITLE
CPBR-3749: bump requests to ~=2.33.0 (CVE-2026-25645)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docker~=7.1.0
 Jinja2~=3.1.0
 PyYAML~=6.0.3
-requests~=2.32.0
+requests~=2.33.0


### PR DESCRIPTION
Fix CVE-2026-25645 by bumping `requests` to `~=2.33.0`.

`requests==2.32.5` is currently pulled into `cp-base-new` (and downstream `cp-jmxterm`) in `confluentinc/common-docker` via this package's `requirements.txt`.

Trace:
- `common-docker/base/Dockerfile.ubi9` runs `pip install confluent-docker-utils@${tag}`
- tag is set by `common-docker/base/pom.xml` → `<git-repo.confluent-docker-utils.tag>v0.0.169</…>`
- `confluent-docker-utils@v0.0.169/requirements.txt`: `requests~=2.32.0` → resolves to `2.32.5` → flagged

Follow-up after this merges and a new tag (e.g. `v0.0.170`) is cut: bump `<git-repo.confluent-docker-utils.tag>` in `confluentinc/common-docker` `pom.xml` on the FedRAMP `8.0.2-cp7` branch (and other affected CP branches).

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749