### PR TITLE
Revert "CPBR-3749: bump requests to ~=2.33.0 (CVE-2026-25645) (#222)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docker~=7.1.0
 Jinja2~=3.1.0
 PyYAML~=6.0.3
-requests~=2.33.0
+requests~=2.32.0


### PR DESCRIPTION
Reverts #222.

Reverts `requests` pin from `~=2.33.0` back to `~=2.32.0`.


Context:
https://pypi.org/project/requests/2.33.0/ -> "Requests officially supports Python 3.10+." 

Some branches common-docker are still on python3.9, whose builds are failing. 
This change will be re-reverted once the builds on common-docker pass.
