### PR TITLE
CPBR-3749: reapply requests bump to ~=2.33.0 (CVE-2026-25645)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docker~=7.1.0
 Jinja2~=3.1.0
 PyYAML~=6.0.3
-requests~=2.32.0
+requests~=2.33.0


### PR DESCRIPTION
Reapplies #222 (reverted in #223). Restores `requests~=2.33.0` to pick up the CVE-2026-25645 fix in `extract_zipped_paths`.

Note: `requests 2.33.x` requires Python ≥3.10. Consumers on Python 3.9 (e.g. cp-base-new on 8.0.2-cp* FedRAMP hotfix) must be on a Python 3.10+ base 

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749